### PR TITLE
[#24] Image Load

### DIFF
--- a/src/ViewManager.ts
+++ b/src/ViewManager.ts
@@ -18,7 +18,7 @@ export class ViewManager {
         this._editorWrapperEl = this._buildEditorWrapperEl();
         
         this._header = new HeaderRoot();
-        this._persister = new PersisterRoot();
+        this._persister = new PersisterRoot(this._model);
         this._canvas = new CanvasRoot(this._model);
         this._menuBar = new MenuBarRoot();
     }

--- a/src/canvas/CanvasRoot.ts
+++ b/src/canvas/CanvasRoot.ts
@@ -2,12 +2,17 @@ import {ModelManager} from "../model/ModelManager";
 import {AbstractView} from "../infra/AbstractView";
 import {LookUpElement} from "../util/LookupElement";
 import autobind from "autobind-decorator";
+import {px} from "../util/CSSUtil";
+import {Palette} from "../util/Palette";
 
 const HTML = `
 <section class="canvas-wrapper">
   <canvas id="canvas"></canvas>
 </section>
 `
+
+const CANVAS_WIDTH = 1050;
+const CANVAS_HEIGHT = 370;
 
 export class CanvasRoot extends AbstractView {
     protected htmlText: string = HTML;
@@ -26,8 +31,15 @@ export class CanvasRoot extends AbstractView {
     
     protected onFirstRender() {
         super.onFirstRender();
-        this._ctx = this._canvasEl.getContext('2d')!;
+        this._initCanvas();
         this._bindEvents();
+    }
+    
+    private _initCanvas(): void {
+        this._ctx = this._canvasEl.getContext('2d')!;
+        this._canvasEl.setAttribute('width', px(CANVAS_WIDTH));
+        this._canvasEl.setAttribute('height',  px(CANVAS_HEIGHT));
+        this._fillCanvasBlack();
     }
     
     private _bindEvents(): void {
@@ -36,6 +48,28 @@ export class CanvasRoot extends AbstractView {
     
     @autobind
     private _onCanvasImageChange(image: HTMLImageElement): void {
-        this._ctx.drawImage(image, 0, 0);
+        const {width, height} = this._getImgRenderingSize(image);
+        this._fillCanvasBlack();
+        this._ctx.drawImage(image, 0, 0, image.width, image.height, (CANVAS_WIDTH - width) / 2,(CANVAS_HEIGHT - height) / 2, width, height);
+    }
+    
+    private _getImgRenderingSize(image: HTMLImageElement): {width: number, height: number} {
+        const {width, height} = image;
+        const diagonal = Math.ceil(Math.sqrt(width * width + height * height));
+        let renderingWidth = width;
+        let renderingHeight = height;
+    
+        if (diagonal > CANVAS_HEIGHT) {
+            const ratio = CANVAS_HEIGHT / diagonal;
+            renderingWidth = width * ratio;
+            renderingHeight = height * ratio;
+        }
+        
+        return {width: renderingWidth, height: renderingHeight};
+    }
+    
+    private _fillCanvasBlack(): void {
+        this._ctx.fillStyle = Palette.BLACK;
+        this._ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
     }
 }

--- a/src/canvas/CanvasRoot.ts
+++ b/src/canvas/CanvasRoot.ts
@@ -1,6 +1,7 @@
 import {ModelManager} from "../model/ModelManager";
 import {AbstractView} from "../infra/AbstractView";
 import {LookUpElement} from "../util/LookupElement";
+import autobind from "autobind-decorator";
 
 const HTML = `
 <section class="canvas-wrapper">
@@ -26,21 +27,15 @@ export class CanvasRoot extends AbstractView {
     protected onFirstRender() {
         super.onFirstRender();
         this._ctx = this._canvasEl.getContext('2d')!;
-        this._loadDefaultImage();
+        this._bindEvents();
     }
     
-    private _loadDefaultImage(): void {
-        const defaultImage = new Image();
-        defaultImage.src = 'https://d3rr2gvhjw0wwy.cloudfront.net/uploads/activity_headers/134196/2000x2000-0-70-26479c61882c4ffeed3d976caf233de2.jpg';
-        
-        defaultImage.addEventListener('load', () => {
-            const canvasBoundingRect = this._canvasEl.getBoundingClientRect();
-            const ratioOfImg = defaultImage.height / defaultImage.width;
-            const canvasWidth = canvasBoundingRect.width < defaultImage.width ? canvasBoundingRect.width : defaultImage.width;
-            // this._ctx.drawImage(defaultImage, 0, 0, canvasWidth, canvasWidth * ratioOfImg);
-            defaultImage.width = 50;
-            defaultImage.height = 50;
-            this._ctx.drawImage(defaultImage, 0, 0);
-        })
+    private _bindEvents(): void {
+        this._model.canvas.on('canvas-image-change', this._onCanvasImageChange);
+    }
+    
+    @autobind
+    private _onCanvasImageChange(image: HTMLImageElement): void {
+        this._ctx.drawImage(image, 0, 0);
     }
 }

--- a/src/component/Button.ts
+++ b/src/component/Button.ts
@@ -18,7 +18,6 @@ export class Button extends AbstractView {
     protected onFirstRender() {
         super.onFirstRender();
         this._setAttribute()
-        this._bindEvents();
     }
     
     public disable(): void {
@@ -39,11 +38,5 @@ export class Button extends AbstractView {
         this.element.style.width = px(this._buttonProps.width);
         this.element.style.height = px(this._buttonProps.height);
         this.element.textContent = this._buttonProps.text;
-    }
-    
-    private _bindEvents(): void {
-        if (this._buttonProps.onClick) {
-            this.element.addEventListener('click', this._buttonProps.onClick);
-        }
     }
 }

--- a/src/component/IButtonProps.ts
+++ b/src/component/IButtonProps.ts
@@ -2,5 +2,4 @@ export interface IButtonProps {
     width: number;
     height: number;
     text: string;
-    onClick?: (e: MouseEvent) => any;
 }

--- a/src/model/Canvas.ts
+++ b/src/model/Canvas.ts
@@ -1,0 +1,21 @@
+import {Watcher} from "../util/Watcher";
+
+type CanvasModelEvent = 'canvas-image-change';
+
+export class CanvasModel {
+    private _watcher: Watcher = new Watcher();
+    private _image: HTMLImageElement | null = null;
+    
+    public setImage(image: HTMLImageElement): void {
+        this._image = image;
+        this._watcher.emit('canvas-image-change', this._image);
+    }
+    
+    public on(eventName: CanvasModelEvent, listener: any): void {
+        this._watcher.on(eventName, listener);
+    }
+    
+    get image(): HTMLImageElement | null {
+        return this._image;
+    }
+}

--- a/src/model/ModelManager.ts
+++ b/src/model/ModelManager.ts
@@ -1,4 +1,13 @@
+import {CanvasModel} from "./Canvas";
+
 export class ModelManager {
+    private _canvas: CanvasModel;
+    
     constructor() {
+        this._canvas = new CanvasModel();
+    }
+    
+    get canvas(): CanvasModel {
+        return this._canvas;
     }
 }

--- a/src/persister/LoadButton.ts
+++ b/src/persister/LoadButton.ts
@@ -1,11 +1,72 @@
 import {Button} from "../component/Button";
+import autobind from 'autobind-decorator';
+import {IButtonProps} from "../component/IButtonProps";
+import {AbstractView} from "../infra/AbstractView";
+import {LookUpElement} from "../util/LookupElement";
+import {ModelManager} from "../model/ModelManager";
 
-export class LoadButton extends Button {
-    constructor() {
-        super({
-            width: 150,
-            height: 30,
-            text: 'Load',
-        });
+const buttonProps: IButtonProps = {
+    width: 150,
+    height: 30,
+    text: 'Load',
+};
+
+const HTML = `
+<div>
+  <input type="file" class="blind image-input" accept="image/*">
+  <!--button -->
+</div>
+`
+
+export class LoadButton extends AbstractView {
+    protected htmlText: string = HTML;
+    private _button: Button;
+    private _model: ModelManager;
+    
+    @LookUpElement('.image-input')
+    private _inputEl!: HTMLInputElement;
+    
+    constructor(model: ModelManager) {
+        super();
+        this._model = model;
+        this._button = new Button(buttonProps);
+    }
+    
+    protected onFirstRender(): void {
+        super.onFirstRender();
+        this._button.render().attachToEl(this.element);
+        this._bindEvents();
+    }
+    
+    private _bindEvents(): void {
+        this.element.addEventListener('click', this._onClick);
+        this._inputEl.addEventListener('change', this._onInputChange);
+    }
+    
+    @autobind
+    private _onClick(e: MouseEvent): void {
+        this._inputEl.click();
+    }
+    
+    @autobind
+    private _onInputChange(e: Event): void {
+        const target = e.target as HTMLInputElement;
+        const imageFile: File = (target.files as FileList)[0];
+        const reader: FileReader = new FileReader();
+        reader.readAsDataURL(imageFile);
+        reader.addEventListener('loadend', this._onFileLoaded);
+    }
+    
+    @autobind
+    private _onFileLoaded(e: ProgressEvent<FileReader>): void {
+        const fileReader = e.target as FileReader;
+        let image = new Image();
+        image.src = fileReader.result as string;
+        image.addEventListener('load', this._onImageLoaded);
+    }
+    
+    @autobind
+    private _onImageLoaded(e: Event): void {
+        this._model.canvas.setImage(e.target as HTMLImageElement);
     }
 }

--- a/src/persister/PersisterRoot.ts
+++ b/src/persister/PersisterRoot.ts
@@ -2,6 +2,7 @@ import {AbstractView} from "../infra/AbstractView";
 import {LoadButton} from "./LoadButton";
 import {DownloadButton} from "./DownloadButton";
 import {LookUpElement} from "../util/LookupElement";
+import {ModelManager} from "../model/ModelManager";
 
 const HTML = `
 <section class="persist-area">
@@ -15,15 +16,22 @@ const HTML = `
 export class PersisterRoot extends AbstractView {
     protected htmlText: string = HTML;
     
+    private _model: ModelManager;
+    
     @LookUpElement('.buttons')
     private _buttonsEl!: HTMLDivElement;
     
     private _loadButton!: LoadButton;
     private _downloadButton!: DownloadButton;
     
+    constructor(model: ModelManager) {
+        super();
+        this._model = model;
+    }
+    
     protected onFirstRender(): void {
         super.onFirstRender();
-        this._loadButton = new LoadButton();
+        this._loadButton = new LoadButton(this._model);
         this._downloadButton = new DownloadButton();
         this._renderButtons();
     }

--- a/src/util/Palette.ts
+++ b/src/util/Palette.ts
@@ -1,0 +1,3 @@
+export const Palette = {
+    BLACK: '#000000',
+}

--- a/static/scss/canvas.scss
+++ b/static/scss/canvas.scss
@@ -2,10 +2,6 @@
   display: flex;
   justify-content: center;
   margin: 0 0 10px 0;
-
-  #canvas {
-    display: block;
-    width: 80%;
-    margin: 0 auto;
-  }
+  width: 100%;
+  height: 370px;
 }

--- a/static/scss/index.scss
+++ b/static/scss/index.scss
@@ -7,6 +7,7 @@
 @import "persister";
 @import "menuBar.scss";
 @import "persister.scss";
+@import "util.scss";
 
 @font-face {
   font-family: 'DOSGothic';

--- a/static/scss/util.scss
+++ b/static/scss/util.scss
@@ -1,3 +1,5 @@
-.grid {
-  
+.blind {
+  position: absolute;
+  top: -999px;
+  left: -999px;
 }


### PR DESCRIPTION
- Button을 상속받아 써야하게 만듬으로서 onClick 속성을 주입해 줄 필요성이 없어짐
- 이에 따라 onClick 관련 속성, 함수 제거
- canvas image 관련 모델 정의
- blind util CSS class 개발
- image를 불러와서 모델로 반영하는 기능
- 모델의 image가 변경되면 이에 따라 canvas의 image를 변경하는 기능
- 모델의 image가 변경되면 이에 따라 canvas의 image를 변경하기 이전에, 나중에 Rotate를 고려해 이미지의 크기를 조절해주는 기능 개발
- 이미지의 대각선 길이가 캔버스의 높이보다 크다면, 대각선 길이를 캔버스의 높이로 맞춰주고, 이에 따라 가로와 세로를 변경해줌.