### PR TITLE
[#24] Image Load - Refactor

### DIFF
--- a/src/canvas/CanvasRoot.ts
+++ b/src/canvas/CanvasRoot.ts
@@ -11,9 +11,6 @@ const HTML = `
 </section>
 `
 
-const CANVAS_WIDTH = 1050;
-const CANVAS_HEIGHT = 370;
-
 export class CanvasRoot extends AbstractView {
     protected htmlText: string = HTML;
     
@@ -31,45 +28,44 @@ export class CanvasRoot extends AbstractView {
     
     protected onFirstRender() {
         super.onFirstRender();
-        this._initCanvas();
         this._bindEvents();
     }
     
-    private _initCanvas(): void {
-        this._ctx = this._canvasEl.getContext('2d')!;
-        this._canvasEl.setAttribute('width', px(CANVAS_WIDTH));
-        this._canvasEl.setAttribute('height',  px(CANVAS_HEIGHT));
-        this._fillCanvasBlack();
+    protected onAttachToEl() {
+        super.onAttachToEl();
+        this._initCanvas();
     }
     
     private _bindEvents(): void {
         this._model.canvas.on('canvas-image-change', this._onCanvasImageChange);
+        this._model.canvas.on('canvas-size-change', this._onCanvasSizeChange);
+    }
+    
+    private _initCanvas(): void {
+        this._ctx = this._canvasEl.getContext('2d')!;
+        
+        const wrapperBoundingRect = this.element.getBoundingClientRect();
+        this._model.canvas.setCanvasSize({
+            width: wrapperBoundingRect.width,
+            height: wrapperBoundingRect.height,
+        });
+        this._fillCanvasBlack();
     }
     
     @autobind
-    private _onCanvasImageChange(image: HTMLImageElement): void {
-        const {width, height} = this._getImgRenderingSize(image);
+    private _onCanvasSizeChange(width: number, height: number): void {
+        this._canvasEl.setAttribute('width', px(width));
+        this._canvasEl.setAttribute('height', px(height));
+    }
+    
+    @autobind
+    private _onCanvasImageChange(image: HTMLImageElement, x: number, y: number, width: number, height: number): void {
         this._fillCanvasBlack();
-        this._ctx.drawImage(image, 0, 0, image.width, image.height, (CANVAS_WIDTH - width) / 2,(CANVAS_HEIGHT - height) / 2, width, height);
+        this._ctx.drawImage(image, 0, 0, image.width, image.height, x, y, width, height);
     }
-    
-    private _getImgRenderingSize(image: HTMLImageElement): {width: number, height: number} {
-        const {width, height} = image;
-        const diagonal = Math.ceil(Math.sqrt(width * width + height * height));
-        let renderingWidth = width;
-        let renderingHeight = height;
-    
-        if (diagonal > CANVAS_HEIGHT) {
-            const ratio = CANVAS_HEIGHT / diagonal;
-            renderingWidth = width * ratio;
-            renderingHeight = height * ratio;
-        }
-        
-        return {width: renderingWidth, height: renderingHeight};
-    }
-    
+
     private _fillCanvasBlack(): void {
         this._ctx.fillStyle = Palette.BLACK;
-        this._ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+        this._ctx.fillRect(0, 0, this._model.canvas.canvasWidth, this._model.canvas.canvasHeight);
     }
 }

--- a/src/model/Canvas.ts
+++ b/src/model/Canvas.ts
@@ -1,14 +1,40 @@
 import {Watcher} from "../util/Watcher";
 
-type CanvasModelEvent = 'canvas-image-change';
+export type CanvasModelEvent = 'canvas-image-change' | 'canvas-size-change';
+
+export type CanvasSize = {
+    width: number;
+    height: number;
+};
 
 export class CanvasModel {
     private _watcher: Watcher = new Watcher();
+    
+    private _canvasWidth: number = 0;
+    private _canvasHeight: number = 0;
     private _image: HTMLImageElement | null = null;
+    private _x: number | null = null;
+    private _y: number | null = null;
+    private _width: number | null = null;
+    private _height: number | null = null;
+    
+    public setCanvasSize(canvasSize: CanvasSize): void {
+        this._canvasWidth = canvasSize.width;
+        this._canvasHeight = canvasSize.height;
+        
+        this._watcher.emit('canvas-size-change', this._canvasWidth, this._canvasHeight);
+    }
     
     public setImage(image: HTMLImageElement): void {
+        const {width, height} = this._calculateImgRenderingSize(image);
+        
         this._image = image;
-        this._watcher.emit('canvas-image-change', this._image);
+        this._x = (this._canvasWidth - width) / 2;
+        this._y = (this._canvasHeight - height) / 2;
+        this._width = width;
+        this._height = height;
+        
+        this._watcher.emit('canvas-image-change', this._image, this._x, this._y, this._width, this._height);
     }
     
     public on(eventName: CanvasModelEvent, listener: any): void {
@@ -17,5 +43,44 @@ export class CanvasModel {
     
     get image(): HTMLImageElement | null {
         return this._image;
+    }
+    
+    get x(): number | null {
+        return this._x;
+    }
+    
+    get y(): number | null {
+        return this._y;
+    }
+    
+    get width(): number | null {
+        return this._width;
+    }
+    
+    get height(): number | null {
+        return this._height;
+    }
+    
+    get canvasWidth(): number {
+        return this._canvasWidth;
+    }
+    
+    get canvasHeight(): number {
+        return this._canvasHeight;
+    }
+    
+    private _calculateImgRenderingSize(image: HTMLImageElement): { width: number, height: number } {
+        const {width, height} = image;
+        const diagonal = Math.ceil(Math.sqrt(width * width + height * height));
+        let renderingWidth = width;
+        let renderingHeight = height;
+
+        if (diagonal > this._canvasHeight) {
+            const ratio = this._canvasHeight / diagonal;
+            renderingWidth = width * ratio;
+            renderingHeight = height * ratio;
+        }
+
+        return {width: renderingWidth, height: renderingHeight};
     }
 }


### PR DESCRIPTION
- 기존에는 View에서 캔버스에 들어갈 이미지의 사이즈를 계산해서 렌더함
- 추후에 x, y, width, height를 이 뷰 외의 장소에서 사용할 수 있게 모델에 반영하고, 모델이 이벤트를 발행하면 이를 캔버스에 반영하는 형태로 변경